### PR TITLE
Fix syntax error in ClientDetails component

### DIFF
--- a/src/components/ClientDetails.tsx
+++ b/src/components/ClientDetails.tsx
@@ -41,8 +41,6 @@ type Note = {
 
 import EditClientModal from './EditClientModal';
 
-import EditClientModal from './EditClientModal';
-
 type Client = {
   id: number;
   name: string;
@@ -135,13 +133,6 @@ export default function ClientDetails({ client, loading, onRefresh, onDeleted }:
     if (onDeleted) onDeleted();
   };
 
-  // Delete client (with confirmation)
-  const handleDeleteClient = async () => {
-    if (!window.confirm('Are you sure you want to delete this client? This will also delete all related commissions, characters, and notes.')) return;
-    await fetch(`/api/clients/${client.id}`, { method: 'DELETE' });
-    if (onDeleted) onDeleted();
-  };
-
   return (
     <div className="p-6">
       <div className="mb-6 flex items-start justify-between">
@@ -187,21 +178,6 @@ export default function ClientDetails({ client, loading, onRefresh, onDeleted }:
           </Button>
         </div>
       </div>
-      <EditClientModal
-        isOpen={showEditClient}
-        onClose={() => setShowEditClient(false)}
-        client={{
-          id: client.id,
-          name: client.name,
-          discordId: client.discordId,
-        }}
-        onUpdated={() => {
-          onRefresh();
-          setShowEditClient(false);
-        }}
-      />
-      </div>
-
       <EditClientModal
         isOpen={showEditClient}
         onClose={() => setShowEditClient(false)}


### PR DESCRIPTION
This pull request resolves a syntax error in the `ClientDetails.tsx` file that was causing a build failure. The error was due to a misplaced component import which has been removed along with redundant code. The `EditClientModal` component was defined twice, leading to the confusion in the syntax. The unnecessary code sections were cleaned up to ensure smooth functionality and maintainability. This change ensures the modal renders properly when needed without causing parsing errors.

---

> This pull request was co-created with Cosine Genie

Original Task: [commissions/rpdtkcxp4cf8](https://cosine.sh/uyj0k4lc37n5/commissions/task/rpdtkcxp4cf8)
Author: Gote Mazzy
