### PR TITLE
Fix Webpack Configuration Validation Error

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,27 +8,17 @@ const nextConfig: NextConfig = {
         // We only want to modify watchOptions in development mode
         // and not for the server-side compilation
         if (dev && !isServer) {
-            // Original ignored patterns
-            const prevIgnored = config.watchOptions.ignored;
+            // Provide only string globs, per webpack 5 schema
+            const ignoreGlobs: string[] = [
+                '**/node_modules/**',    // webpack default (as a glob)
+                '**/*.db',
+                '**/.db',
+                '**/prisma/dev.db',
+            ];
 
-            // Your new patterns
-            const dbPatterns = ["**/*.db", "**/.db", "**/prisma/dev.db"];
-
-            let newIgnored: (string | RegExp)[] = [];
-
-            // Combine existing ignored patterns with your new ones
-            if (Array.isArray(prevIgnored)) {
-                newIgnored = [...prevIgnored, ...dbPatterns];
-            } else if (typeof prevIgnored === "string" || prevIgnored instanceof RegExp) {
-                newIgnored = [prevIgnored, ...dbPatterns];
-            } else {
-                newIgnored = dbPatterns;
-            }
-
-            // Create a new 'watchOptions' object instead of mutating the existing one
             config.watchOptions = {
                 ...config.watchOptions,
-                ignored: newIgnored,
+                ignored: ignoreGlobs,
             };
         }
 


### PR DESCRIPTION
This pull request addresses a Webpack configuration validation error encountered during development. The issue was due to the `ignored` patterns in the `watchOptions` not conforming to the expected schema, specifically requiring non-empty strings.

In the `next.config.ts`, I've modified the `watchOptions.ignored` to provide only string glob patterns compatible with Webpack 5. The new patterns include:
- `**/node_modules/**`
- `**/*.db`
- `**/.db`
- `**/prisma/dev.db`

This fix enables the proper functioning of the development server without triggering validation errors.

---

> This pull request was co-created with Cosine Genie

Original Task: [commissions/xftjf8biha1j](https://cosine.sh/uyj0k4lc37n5/commissions/task/xftjf8biha1j)
Author: Gote Mazzy
